### PR TITLE
 Migrate "actions/node-versions" CI to GA: Add workflow for create release PR

### DIFF
--- a/.github/workflows/create_pr_workflow.yml
+++ b/.github/workflows/create_pr_workflow.yml
@@ -1,0 +1,48 @@
+name: Create Pull Request
+
+on: 
+    workflow_dispatch:
+    release:
+      types: [edited]
+
+jobs:
+
+  build:
+    env:
+      REPOSITORY_NAME: "node-versions"
+      BRANCH_NAME: "update-versions-manifest-file"
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: env
+      run: Get-ChildItem -Path Env:\
+      shell: pwsh
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Create versions-manifest.json
+      run: |
+        ./helpers/packages-generation/manifest-generator.ps1 -GitHubRepositoryOwner "${{github.repository_owner}}" `
+                                                             -GitHubRepositoryName "$env:REPOSITORY_NAME"`
+                                                             -GitHubAccessToken "${{secrets.GITHUB_TOKEN}}"`
+                                                             -OutputFile "./versions-manifest.json"`
+                                                             -ConfigurationFile "./config/node-manifest-config.json"
+      shell: pwsh
+
+    - name: Create GitHub PR
+      run: |
+        $formattedDate = Get-Date -Format "MM/dd/yyyy"
+        ./helpers/github/create-pull-request.ps1 `
+                            -RepositoryOwner "${{github.repository_owner}}" `
+                            -RepositoryName "$env:REPOSITORY_NAME" `
+                            -AccessToken "${{secrets.GITHUB_TOKEN}}" `
+                            -BranchName "$env:BRANCH_NAME" `
+                            -CommitMessage "Update versions-manifest" `
+                            -PullRequestTitle "[versions-manifest] Update for release from ${formattedDate}" `
+                            -PullRequestBody "Update versions-manifest.json for release from ${formattedDate}"
+      shell: pwsh
+
+

--- a/.github/workflows/create_pr_workflow.yml
+++ b/.github/workflows/create_pr_workflow.yml
@@ -1,8 +1,5 @@
 name: Create Pull Request
-on: 
-    workflow_dispatch:
-    release:
-      types: [edited]
+on: workflow_dispatch
 jobs:
   build:
     name: Create Pull Request

--- a/.github/workflows/create_pr_workflow.yml
+++ b/.github/workflows/create_pr_workflow.yml
@@ -1,38 +1,31 @@
 name: Create Pull Request
-
 on: 
     workflow_dispatch:
     release:
       types: [edited]
-
 jobs:
-
   build:
+    name: Create Pull Request
     env:
       REPOSITORY_NAME: "node-versions"
       BRANCH_NAME: "update-versions-manifest-file"
-
     runs-on: ubuntu-latest
-
     steps:
-    - name: env
-      run: Get-ChildItem -Path Env:\
-      shell: pwsh
-
     - uses: actions/checkout@v2
       with:
         submodules: true
 
     - name: Create versions-manifest.json
+      shell: pwsh
       run: |
         ./helpers/packages-generation/manifest-generator.ps1 -GitHubRepositoryOwner "${{github.repository_owner}}" `
                                                              -GitHubRepositoryName "$env:REPOSITORY_NAME"`
                                                              -GitHubAccessToken "${{secrets.GITHUB_TOKEN}}"`
                                                              -OutputFile "./versions-manifest.json"`
                                                              -ConfigurationFile "./config/node-manifest-config.json"
-      shell: pwsh
 
     - name: Create GitHub PR
+      shell: pwsh
       run: |
         $formattedDate = Get-Date -Format "MM/dd/yyyy"
         ./helpers/github/create-pull-request.ps1 `
@@ -43,6 +36,4 @@ jobs:
                             -CommitMessage "Update versions-manifest" `
                             -PullRequestTitle "[versions-manifest] Update for release from ${formattedDate}" `
                             -PullRequestBody "Update versions-manifest.json for release from ${formattedDate}"
-      shell: pwsh
-
 


### PR DESCRIPTION
This PR is a part of [Migrate "actions/node-versions" CI to GA #920](https://github.com/actions/virtual-environments-internal/issues/920). 
Replaces the logic presented in this [release](https://github.visualstudio.com/virtual-environments/_releaseProgress?releaseId=689&environmentId=1378&_a=release-task-editor).
The first step creates versions-manifest.json file. The second step created a PR for release.
This workflow is started when a release is updated and also can be triggered manually.